### PR TITLE
fix pin16 issue on pizerow

### DIFF
--- a/nanosound_oled/nanodac_oled.py
+++ b/nanosound_oled/nanodac_oled.py
@@ -531,7 +531,11 @@ if (model == "DAC2"):
     GPIO.add_event_detect(GPIOSWMenuButtonNo, GPIO.BOTH, callback=optionButPress, bouncetime=30)
 
 GPIO.setup(GPIOButtonNo, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
-GPIO.add_event_detect(GPIOButtonNo, GPIO.BOTH, callback=optionButPress, bouncetime=30)
+#pin 16 gives errors on pi zerow in volumio using OLED-only displays
+try:
+    GPIO.add_event_detect(GPIOButtonNo, GPIO.BOTH, callback=optionButPress, bouncetime=30)
+except RuntimeError as err:
+    print("OS error: {0}".format(err))
 
 if (hasOLED):
     screen = Screen(device, isColour, isScroll)


### PR DESCRIPTION
ignores issues on GPIO to allow the OLED operation if not all pins are supported (specifically, volumio on pi zerow)